### PR TITLE
Changed Single Line Comments Defined As Multiline Comments

### DIFF
--- a/piston/colorschemes/dracula.py
+++ b/piston/colorschemes/dracula.py
@@ -17,14 +17,14 @@ from pygments.token import (
 
 
 class DraculaStyle:
-    """Configuration for Dracula Theme."""
+    # Configuration for Dracula Theme.
 
     def __init__(self) -> None:
         self.background_color = "#282a36"
         self.default_style = ""
 
     def get_dracula(self) -> Style:
-        """Configuration for Dracula Theme."""
+        # Configuration for Dracula Theme.
         return style_from_pygments_dict(
             {
                 Comment: "#6272a4",

--- a/piston/colorschemes/gruvbox.py
+++ b/piston/colorschemes/gruvbox.py
@@ -12,13 +12,13 @@ from pygments.token import (
 
 
 class GruvboxStyle:
-    """Configuration for Gruvbox Theme."""
+    # Configuration for Gruvbox Theme.
 
     def __init__(self) -> None:
         self.background_color = "#282828"
 
     def get_gruvbox(self) -> Style:
-        """Configuration for Gruvbox Theme."""
+        # Configuration for Gruvbox Theme.
         return style_from_pygments_dict(
             {
                 Comment.Preproc: "noinherit #8ec07c",

--- a/piston/colorschemes/nord.py
+++ b/piston/colorschemes/nord.py
@@ -14,7 +14,7 @@ from pygments.token import (
 
 
 class NordStyle:
-    """Configuration for Nord Theme."""
+    # Configuration for Nord Theme.
 
     def __init__(self) -> None:
         self.nord0 = "#2e3440"
@@ -42,7 +42,7 @@ class NordStyle:
         self.default = self.nord4
 
     def get_nord(self) -> Style:
-        """Configuration for Nord Theme."""
+        # Configuration for Nord Theme.
         return style_from_pygments_dict(
             {
                 Whitespace: self.nord4,

--- a/piston/commands/from_input.py
+++ b/piston/commands/from_input.py
@@ -16,7 +16,7 @@ from rich.console import Console
 
 
 class FromInput:
-    """Run code from input."""
+    # Run code from input.
 
     def __init__(self) -> None:
         init_lexers()
@@ -28,7 +28,7 @@ class FromInput:
         self.themes = list(get_all_styles()) + schemes
 
     def get_lang(self) -> str:
-        """Prompt the user for the programming language, close program if language not supported."""
+        # Prompt the user for the programming language, close program if language not supported.
         language = self.console.input("[green]Enter language:[/green] ").lower()
 
         if language not in self.languages:
@@ -37,12 +37,12 @@ class FromInput:
         return language
 
     def get_args(self) -> List[str]:
-        """Prompt the user for the command line arguments."""
+        # Prompt the user for the command line arguments.
         args = self.console.input("[green]Enter your args separated by comma:[/green] ")
         return [x for x in args.strip().split(",") if x]
 
     def get_stdin(self) -> str:
-        """Prompt the user for the standard input."""
+        # Prompt the user for the standard input.
         stdin = self.console.input(
             "[green]Enter your stdin arguments by comma:[/green] "
         )

--- a/piston/commands/from_link.py
+++ b/piston/commands/from_link.py
@@ -26,7 +26,7 @@ class FromLink:
         self.themes = list(get_all_styles()) + schemes
 
     def get_lang(self) -> str:
-        """Prompt the user for the programming language, close program if language not supported."""
+        # Prompt the user for the programming language, close program if language not supported.
         language = self.console.input("[green]Enter language:[/green] ").lower()
 
         if language not in self.languages:
@@ -35,19 +35,19 @@ class FromLink:
         return language
 
     def get_args(self) -> List[str]:
-        """Prompt the user for the command line arguments."""
+        # Prompt the user for the command line arguments.
         args = self.console.input("[green]Enter your args separated by comma:[/green] ")
         return [x for x in args.strip().split(",") if x]
 
     def get_stdin(self) -> str:
-        """Prompt the user for the standard input."""
+        # Prompt the user for the standard input.
         stdin = self.console.input(
             "[green]Enter your stdin arguments by comma:[/green] "
         )
         return "\n".join([x for x in stdin.strip().split(",") if x])
 
     def get_code(self) -> Union[bool, str]:
-        """Prompt the user for the pastebin link."""
+        # Prompt the user for the pastebin link
         link = self.console.input("[green]Enter the link:[/green] ").lower()
 
         base_url = urllib.parse.quote_plus(

--- a/piston/commands/from_shell.py
+++ b/piston/commands/from_shell.py
@@ -19,7 +19,7 @@ from rich.console import Console
 
 @dataclass
 class PistonQuery:
-    """Represents the payload sent to the Piston API."""
+    # Represents the payload sent to the Piston API.
 
     code: str
     args: List[str]
@@ -27,7 +27,7 @@ class PistonQuery:
 
 
 class FromShell:
-    """Run code from a shell environment."""
+    # Run code from a shell environment.
 
     def __init__(self):
         init_lexers()
@@ -39,7 +39,7 @@ class FromShell:
         self.prompt_session = None
 
     def set_prompt_session(self) -> None:
-        """Set the prompt session to use for input."""
+        # Set the prompt session to use for input.
         self.prompt_session = PromptSession(
             Shell.promp_start,
             include_default_pygments_style=False,
@@ -49,7 +49,7 @@ class FromShell:
         )
 
     def set_style(self, theme: str) -> None:
-        """Set the theme for prompt_toolkit."""
+        # Set the theme for prompt_toolkit.
         if theme in self.themes:
             try:
                 self.style = sfpc(get_style_by_name(theme))
@@ -59,7 +59,7 @@ class FromShell:
             self.style = sfpc(get_style_by_name("solarized-dark"))
 
     def set_language(self, language: str) -> None:
-        """Prompt the user for the programming language, close program if language not supported."""
+        # Prompt the user for the programming language, close program if language not supported.
         if language not in languages_:
             self.console.print("[bold red]Language is not supported![/bold red]")
             Utils.close()
@@ -67,19 +67,19 @@ class FromShell:
         self.language = language
 
     def get_args(self) -> List[str]:
-        """Prompt the user for the command line arguments."""
+        # Prompt the user for the command line arguments.
         args = self.console.input("[green]Enter your args separated by comma:[/green] ")
         return [x for x in args.strip().split(",") if x]
 
     def get_stdin(self) -> str:
-        """Prompt the user for the standard input."""
+        # Prompt the user for the standard input.
         stdin = self.console.input(
             "[green]Enter your stdin arguments by comma:[/green] "
         )
         return "\n".join([x for x in stdin.strip().split(",") if x])
 
     def query_piston(self, payload: PistonQuery) -> dict:
-        """Send a post request to the piston API with the code parameter."""
+        # Send a post request to the piston API with the code parameter.
         output_json = {
             "language": self.language,
             "source": payload.code,
@@ -94,7 +94,7 @@ class FromShell:
             ).json()
 
     def prompt(self) -> PistonQuery:
-        """Prompt the user for code input."""
+        # Prompt the user for code input.
         code = self.prompt_session.prompt(
             style=self.style,
         )
@@ -109,7 +109,7 @@ class FromShell:
         )
 
     def run_shell(self, language: str, theme: str) -> None:
-        """Run the shell."""
+        # Run the shell.
         self.console.print(
             "[bold blue]NOTE: stdin and args will be prompted after code. "
             "Use escape + enter to finish writing the code. "

--- a/piston/utilities/prompt_continuation.py
+++ b/piston/utilities/prompt_continuation.py
@@ -2,5 +2,5 @@ from piston.utilities.constants import Shell
 
 
 def prompt_continuation(*args) -> str:
-    """Prompt continuation method for prompt_toolkit."""
+    # Prompt continuation method for prompt_toolkit.
     return Shell.promt_continuation

--- a/piston/utilities/utils.py
+++ b/piston/utilities/utils.py
@@ -6,7 +6,7 @@ class Utils:
     """TODO: Write a Docstring here."""
 
     def close(self) -> None:
-        """Exit the program."""
+        # Exit the program.
         try:
             sys.exit(1)
         except SystemExit:


### PR DESCRIPTION
## Description
I have changed the commenting convention so comments that are on a single line are defined  using a single line comment. instead of multi-line comment.

example

```diff
before 
- """sample text"""
after 
+ # sample text
```

## I have:

- [ ] Join the [**Piston CLI Discord Community**](https://discord.gg/c7dZ4zdGQT)?
- [ ] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
