### PR TITLE
Change themelist flag to conform to standards

### DIFF
--- a/piston/commands/base.py
+++ b/piston/commands/base.py
@@ -43,7 +43,7 @@ class Base:
         )
 
         prog.add_argument(
-            "-tl",
+            "-T",
             "--themelist",
             action="store_true",
             help="List all the available themes/colorschemes",


### PR DESCRIPTION
## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->

None

## Description/Reasoning
<!-- Describe how you've implemented your changes. -->

Changed the `-tl` option to `-T`, most unix/linux tools have one dash for an option, and two for the full option. The two letters after one dash didn't conform to standards.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Piston CLI Discord Community**](https://discord.gg/c7dZ4zdGQT)?
- [ ] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
