### PR TITLE
Added missing dependency and missing init file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup_args = dict(
     },
 )
 
-install_requires = ["rich", "prompt-toolkit", "requests", "pygments"]
+install_requires = ["rich", "prompt-toolkit", "requests", "pygments", "pyyaml"]
 
 if __name__ == "__main__":
     setup(**setup_args, install_requires=install_requires)


### PR DESCRIPTION
Added missing dependency `pyyaml` and missing init file `__init__.py` in `/piston-cli/piston/configuration/validators/`. These two additions allow it to work "out-of-the-box" (at least, on my laptop-server with a fresh python)

- [x] Join the [**Piston CLI Discord Community**](https://discord.gg/c7dZ4zdGQT)?
- [ ] If dependencies have been added or updated, run `pipenv lock`?
- [ ] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?

I don't have `pipenv`, or even know how it works. I can do these things if you'd like, but I've only added one 6-char string and a blank file.